### PR TITLE
Shift PHP versions, add Coveralls

### DIFF
--- a/src/Common/README.md
+++ b/src/Common/README.md
@@ -1,0 +1,6 @@
+# Organization\Name
+Description
+
+[![](https://github.com/organization/name/workflows/PHPUnit/badge.svg)](https://github.com/organization/name/actions?query=workflow%3A%22PHPUnit)
+[![](https://github.com/organization/name/workflows/PHPStan/badge.svg)](https://github.com/organization/name/actions?query=workflow%3A%22PHPStan)
+[![Coverage Status](https://coveralls.io/repos/github/organization/name/badge.svg?branch=develop)](https://coveralls.io/github/organization/name?branch=develop)

--- a/src/Library/.github/workflows/analyze.yml
+++ b/src/Library/.github/workflows/analyze.yml
@@ -22,8 +22,12 @@ on:
 
 jobs:
   build:
-    name: Analyze code
+    name: PHP ${{ matrix.php-versions }} Static Analysis
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
           extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
 
@@ -60,7 +64,7 @@ jobs:
           restore-keys: ${{ runner.os }}-phpstan-
 
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 

--- a/src/Library/.github/workflows/test.yml
+++ b/src/Library/.github/workflows/test.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   main:
-    name: Build and test
+    name: PHP ${{ matrix.php-versions }} Unit Tests
 
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0']
 
     runs-on: ubuntu-latest
 
@@ -44,9 +44,29 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+        run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Test with PHPUnit
         run: vendor/bin/phpunit --verbose --coverage-text
+
+      - if: matrix.php-versions == '7.4'
+        name: Run Coveralls
+        run: |
+          composer global require php-coveralls/php-coveralls:^2.4
+          php-coveralls --coverage_clover=build/logs/clover.xml -v
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
+
+  coveralls:
+    needs: [main]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/src/Library/composer.json
+++ b/src/Library/composer.json
@@ -24,16 +24,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"php" : ">=7.2"
+		"php" : "^7.3|^8.0"
 	},
 	"require-dev": {
 		"codeigniter4/codeigniter4": "dev-develop",
-		"codeigniter4/codeigniter4-standard": "^1.0",
-		"fzaninotto/faker": "^1.9@dev",
-		"mikey179/vfsstream": "^1.6",
-		"phpstan/phpstan": "^0.12",
-		"phpunit/phpunit": "^8.5",
-		"squizlabs/php_codesniffer": "^3.5"
+		"tatter/tools": "^1.3"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/src/Library/phpunit.xml.dist
+++ b/src/Library/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
 		backupGlobals="false"
 		colors="true"
 		convertErrorsToExceptions="true"
@@ -8,34 +9,39 @@
 		stopOnError="false"
 		stopOnFailure="false"
 		stopOnIncomplete="false"
-		stopOnSkipped="false">
+		stopOnSkipped="false"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">./src</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">./src/Views</directory>
+			<file>./src/Config/Routes.php</file>
+		</exclude>
+		<report>
+			<clover outputFile="build/logs/clover.xml"/>
+			<html outputDirectory="build/logs/html"/>
+			<php outputFile="build/logs/coverage.serialized"/>
+			<text outputFile="php://stdout" showUncoveredFiles="false"/>
+		</report>
+	</coverage>
+
 	<testsuites>
 		<testsuite name="app">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>
 
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">./src</directory>
-			<exclude>
-				<directory suffix=".php">./src/Views</directory>
-				<file>./src/Config/Routes.php</file>
-			</exclude>
-		</whitelist>
-	</filter>
-
 	<logging>
-		<log type="coverage-html" target="build/logs/html"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-php" target="build/logs/coverage.serialized"/>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-		<log type="testdox-html" target="build/logs/testdox.html"/>
-		<log type="testdox-text" target="build/logs/testdox.txt"/>
-		<log type="junit" target="build/logs/logfile.xml"/>
+		<testdoxHtml outputFile="build/logs/testdox.html"/>
+		<testdoxText outputFile="build/logs/testdox.txt"/>
+		<junit outputFile="build/logs/logfile.xml"/>
 	</logging>
 
 	<php>
+		<env name="XDEBUG_MODE" value="coverage"/>
 		<server name="app.baseURL" value="http://example.com"/>
 
 		<!-- Directory containing phpunit.xml -->
@@ -51,11 +57,13 @@
 		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
 
 		<!-- Database configuration -->
-<!--	<env name="database.tests.hostname" value="localhost"/>  -->
-<!--	<env name="database.tests.database" value="tests"/>	     -->
-<!--	<env name="database.tests.username" value="tests_user"/> -->
-<!--	<env name="database.tests.password" value=""/>		     -->
-<!--	<env name="database.tests.DBDriver" value="MySQLi"/>	 -->
-<!--	<env name="database.tests.DBPrefix" value="tests_"/>	 -->
+		<!-- Uncomment to use alternate testing database configuration
+		<env name="database.tests.hostname" value="localhost"/>
+		<env name="database.tests.database" value="tests"/>
+		<env name="database.tests.username" value="tests_user"/>
+		<env name="database.tests.password" value=""/>
+		<env name="database.tests.DBDriver" value="MySQLi"/>
+		<env name="database.tests.DBPrefix" value="tests_"/>
+		-->
 	</php>
 </phpunit>

--- a/src/Patches/Tools.php
+++ b/src/Patches/Tools.php
@@ -14,12 +14,12 @@ class Tools extends BaseSource implements SourceInterface
 	 */
 	public $paths = [
 		[
-			'from'    => ROOTPATH . 'vendor/tatter/tools/src/Common',
-			'to'      => '',
+			'from' => ROOTPATH . 'vendor/tatter/tools/src/Common',
+			'to'   => '',
 		],
 		[
-			'from'    => ROOTPATH . 'vendor/tatter/tools/src/Project',
-			'to'      => '',
+			'from' => ROOTPATH . 'vendor/tatter/tools/src/Project',
+			'to'   => '',
 		],
 	];
 }

--- a/src/Project/.github/workflows/analyze.yml
+++ b/src/Project/.github/workflows/analyze.yml
@@ -22,8 +22,12 @@ on:
 
 jobs:
   build:
-    name: Analyze code
+    name: PHP ${{ matrix.php-versions }} Static Analysis
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +35,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
           extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
 

--- a/src/Project/.github/workflows/test.yml
+++ b/src/Project/.github/workflows/test.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   main:
-    name: Build and test
+    name: PHP ${{ matrix.php-versions }} Unit Tests
 
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0']
 
     runs-on: ubuntu-latest
 
@@ -50,3 +50,23 @@ jobs:
 
       - name: Test with PHPUnit
         run: vendor/bin/phpunit --verbose --coverage-text
+
+      - if: matrix.php-versions == '7.4'
+        name: Run Coveralls
+        run: |
+          composer global require php-coveralls/php-coveralls:^2.4
+          php-coveralls --coverage_clover=build/logs/clover.xml -v
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: PHP ${{ matrix.php-versions }} - ${{ matrix.db-platforms }}
+
+  coveralls:
+    needs: [main]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/src/Project/phpunit.xml.dist
+++ b/src/Project/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
 		backupGlobals="false"
 		colors="true"
 		convertErrorsToExceptions="true"
@@ -8,34 +9,39 @@
 		stopOnError="false"
 		stopOnFailure="false"
 		stopOnIncomplete="false"
-		stopOnSkipped="false">
+		stopOnSkipped="false"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+
+	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">./app</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">./app/Views</directory>
+			<file>./app/Config/Routes.php</file>
+		</exclude>
+		<report>
+			<clover outputFile="build/logs/clover.xml"/>
+			<html outputDirectory="build/logs/html"/>
+			<php outputFile="build/logs/coverage.serialized"/>
+			<text outputFile="php://stdout" showUncoveredFiles="false"/>
+		</report>
+	</coverage>
+
 	<testsuites>
 		<testsuite name="app">
 			<directory>./tests</directory>
 		</testsuite>
 	</testsuites>
 
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">./app</directory>
-			<exclude>
-				<directory suffix=".php">./app/Views</directory>
-				<file>./app/Config/Routes.php</file>
-			</exclude>
-		</whitelist>
-	</filter>
-
 	<logging>
-		<log type="coverage-html" target="build/logs/html"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-php" target="build/logs/coverage.serialized"/>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-		<log type="testdox-html" target="build/logs/testdox.html"/>
-		<log type="testdox-text" target="build/logs/testdox.txt"/>
-		<log type="junit" target="build/logs/logfile.xml"/>
+		<testdoxHtml outputFile="build/logs/testdox.html"/>
+		<testdoxText outputFile="build/logs/testdox.txt"/>
+		<junit outputFile="build/logs/logfile.xml"/>
 	</logging>
 
 	<php>
+		<env name="XDEBUG_MODE" value="coverage"/>
 		<server name="app.baseURL" value="http://example.com"/>
 
 		<!-- Directory containing phpunit.xml -->
@@ -51,11 +57,13 @@
 		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
 
 		<!-- Database configuration -->
-<!--	<env name="database.tests.hostname" value="localhost"/>  -->
-<!--	<env name="database.tests.database" value="tests"/>	     -->
-<!--	<env name="database.tests.username" value="tests_user"/> -->
-<!--	<env name="database.tests.password" value=""/>		     -->
-<!--	<env name="database.tests.DBDriver" value="MySQLi"/>	 -->
-<!--	<env name="database.tests.DBPrefix" value="tests_"/>	 -->
+		<!-- Uncomment to use alternate testing database configuration
+		<env name="database.tests.hostname" value="localhost"/>
+		<env name="database.tests.database" value="tests"/>
+		<env name="database.tests.username" value="tests_user"/>
+		<env name="database.tests.password" value=""/>
+		<env name="database.tests.DBDriver" value="MySQLi"/>
+		<env name="database.tests.DBPrefix" value="tests_"/>
+		-->
 	</php>
 </phpunit>

--- a/src/composer.php
+++ b/src/composer.php
@@ -63,7 +63,7 @@ $output = [
 			'role'     => 'Developer',
 		]
 	],
-	'require'      => $input['require'] ?? ['php' => '^7.3'],
+	'require'      => $input['require'] ?? ['php' => '^7.3|^8.0'],
 	'require-dev'  => $input['require-dev'] ?? [], // Additional requirements added by main script
 	'autoload'     => $input['autoload'] ?? [], // Additional handling below
 	'autoload-dev' => $input['autoload-dev'] ?? [


### PR DESCRIPTION
* Drops PHP 7.2
* Adds PHP 8.0 for dependency and Actions
* Includes Coveralls in test workflow
* Numerous updates and bugfixes