### PR TITLE
Move Infection to action

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -65,10 +65,6 @@ jobs:
           key: ${{ runner.os }}-phpstan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-phpstan-
 
-      # Infection does not support 7.3 so remove it before running Composer
-      - if: matrix.php-versions == '7.3'
-        run: composer remove --no-progress --no-update --no-scripts infection/infection
-
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,9 +70,10 @@ jobs:
 
   coveralls:
     needs: [main]
+    name: Coveralls Finished
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
+      - name: Upload Coveralls results
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      # Infection does not support 7.3 so remove it before running Composer
-      - if: matrix.php-versions == '7.3'
-        run: composer remove --no-progress --no-update --no-scripts infection/infection
-
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
@@ -57,11 +53,12 @@ jobs:
         env:
           TERM: xterm-256color
 
-      - if: matrix.php-versions != '7.3'
+      - if: matrix.php-versions == '8.0'
         name: Mutate with Infection
         run: |
+          composer global require infection/infection
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php vendor/bin/infection --threads=2 --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github
+          infection --threads=2 --coverage=build/phpunit --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github
 
       - if: matrix.php-versions == '8.0'
         name: Run Coveralls

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
 		"ergebnis/composer-normalize": "^2.9",
 		"fakerphp/faker": "^1.9",
 		"friendsofphp/php-cs-fixer": "^2.16",
-		"infection/infection": "^0.21.0",
 		"mikey179/vfsstream": "^1.6",
 		"php-coveralls/php-coveralls": "^2.4",
 		"phpstan/phpstan": "^0.12",

--- a/src/Library/.github/workflows/analyze.yml
+++ b/src/Library/.github/workflows/analyze.yml
@@ -65,10 +65,6 @@ jobs:
           key: ${{ runner.os }}-phpstan-${{ github.sha }}
           restore-keys: ${{ runner.os }}-phpstan-
 
-      # Infection does not support 7.3 so remove it before running Composer
-      - if: matrix.php-versions == '7.3'
-        run: composer remove --no-progress --no-update --no-scripts --dev infection/infection
-
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:

--- a/src/Library/.github/workflows/test.yml
+++ b/src/Library/.github/workflows/test.yml
@@ -70,9 +70,10 @@ jobs:
 
   coveralls:
     needs: [main]
+    name: Coveralls Finished
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
+      - name: Upload Coveralls results
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Library/.github/workflows/test.yml
+++ b/src/Library/.github/workflows/test.yml
@@ -43,10 +43,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      # Infection does not support 7.3 so remove it before running Composer
-      - if: matrix.php-versions == '7.3'
-        run: composer remove --no-progress --no-update --no-scripts --dev infection/infection
-
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
@@ -57,11 +53,12 @@ jobs:
         env:
           TERM: xterm-256color
 
-      - if: matrix.php-versions != '7.3'
+      - if: matrix.php-versions == '8.0'
         name: Mutate with Infection
         run: |
+          composer global require infection/infection
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php vendor/bin/infection --threads=2 --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github --min-msi=80
+          infection --threads=2 --coverage=build/phpunit --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github
 
       - if: matrix.php-versions == '8.0'
         name: Run Coveralls

--- a/src/Project/.github/workflows/test.yml
+++ b/src/Project/.github/workflows/test.yml
@@ -43,10 +43,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      # Infection does not support 7.3 so remove it before running Composer
-      - if: matrix.php-versions == '7.3'
-        run: composer remove --no-progress --no-update --no-scripts --dev infection/infection
-
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
@@ -57,11 +53,12 @@ jobs:
         env:
           TERM: xterm-256color
 
-      - if: matrix.php-versions != '7.3'
+      - if: matrix.php-versions == '8.0'
         name: Mutate with Infection
         run: |
+          composer global require infection/infection
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php vendor/bin/infection --threads=2 --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github --min-msi=80
+          infection --threads=2 --coverage=build/phpunit --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github
 
       - if: matrix.php-versions == '8.0'
         name: Run Coveralls

--- a/src/Project/.github/workflows/test.yml
+++ b/src/Project/.github/workflows/test.yml
@@ -70,9 +70,10 @@ jobs:
 
   coveralls:
     needs: [main]
+    name: Coveralls Finished
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
+      - name: Upload Coveralls results
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/composer.php
+++ b/src/composer.php
@@ -99,7 +99,7 @@ foreach ($keys as $key)
 
 // Make sure development scripts are set
 $output['scripts']['analyze'] = 'phpstan analyze';
-$output['scripts']['mutate'] = 'infection --threads=2 --coverage=build/phpunit';
+$output['scripts']['mutate']  = 'infection --threads=2 --coverage=build/phpunit';
 $output['scripts']['style']   = 'phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 tests/ ' . ($type === 'project' ? 'app/' : 'src/');
 $output['scripts']['test']    = 'phpunit';
 


### PR DESCRIPTION
The Infection integration with 7.3 workaround didn't work out because downstream packages cannot remove a dependency of a dependency. This removes Infection altogether and relies on `composer global require infection/infection` locally and in Actions to access it.