### PR TITLE
GD and SpeedTrap

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"ergebnis/composer-normalize": "^2.9",
 		"fakerphp/faker": "^1.9",
 		"friendsofphp/php-cs-fixer": "^2.16",
+		"johnkary/phpunit-speedtrap": "^3.3",
 		"mikey179/vfsstream": "^1.6",
 		"php-coveralls/php-coveralls": "^2.4",
 		"phpstan/phpstan": "^0.12",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,10 @@
 		</testsuite>
 	</testsuites>
 
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+	</listeners>
+
 	<logging>
 		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
 		<testdoxText outputFile="build/phpunit/testdox.txt"/>

--- a/src/Library/.github/FUNDING.yml
+++ b/src/Library/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: tattersoftware
-custom: "https://paypal.me/tatter"

--- a/src/Library/.github/workflows/analyze.yml
+++ b/src/Library/.github/workflows/analyze.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/src/Library/.github/workflows/test.yml
+++ b/src/Library/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/src/Library/phpunit.xml.dist
+++ b/src/Library/phpunit.xml.dist
@@ -36,6 +36,10 @@
 		</testsuite>
 	</testsuites>
 
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+	</listeners>
+
 	<logging>
 		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
 		<testdoxText outputFile="build/phpunit/testdox.txt"/>

--- a/src/Project/.github/workflows/analyze.yml
+++ b/src/Project/.github/workflows/analyze.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/src/Project/.github/workflows/test.yml
+++ b/src/Project/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/src/Project/phpstan.neon.dist
+++ b/src/Project/phpstan.neon.dist
@@ -7,6 +7,7 @@ parameters:
 	bootstrapFiles:
 		- vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php
 	excludes_analyse:
+		- app/Commands/Test.php
 		- app/Config/Routes.php
 		- app/Views/*
 	ignoreErrors:

--- a/src/Project/phpunit.xml.dist
+++ b/src/Project/phpunit.xml.dist
@@ -36,6 +36,10 @@
 		</testsuite>
 	</testsuites>
 
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+	</listeners>
+
 	<logging>
 		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
 		<testdoxText outputFile="build/phpunit/testdox.txt"/>

--- a/src/composer.php
+++ b/src/composer.php
@@ -99,7 +99,7 @@ foreach ($keys as $key)
 
 // Make sure development scripts are set
 $output['scripts']['analyze'] = 'phpstan analyze';
-$output['scripts']['mutate']  = 'infection --threads=2 --coverage=build/phpunit';
+$output['scripts']['mutate']  = 'infection --threads=2 --skip-initial-tests --coverage=build/phpunit';
 $output['scripts']['style']   = 'phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 tests/ ' . ($type === 'project' ? 'app/' : 'src/');
 $output['scripts']['test']    = 'phpunit';
 


### PR DESCRIPTION
* With the updates to GitHub Action servers the `GD` extension is not always available by default. This PR adds it explicitly to make sure all modules can use it
* Adds SpeedTrap for slow unit test detection during PHPUnit