### PR TITLE
Remove Composer Auth

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Run static analysis
         run: vendor/bin/phpstan analyze

--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run comparison
         uses: docker://nyholm/roave-bc-check-ga
         env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Enable Tachycardia
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"nexusphp/tachycardia": "^1.0",
 		"php-coveralls/php-coveralls": "^2.4",
 		"phpstan/phpstan": "^0.12",
-		"phpunit/phpunit": "^9.0",
+		"phpunit/phpunit": "^9.3",
 		"squizlabs/php_codesniffer": "^3.5",
 		"tatter/patches": "^1.0"
 	},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,7 @@
 		<exclude>
 			<directory suffix=".php">./src/Views</directory>
 			<file>./src/Config/Routes.php</file>
+			<file>./src/rector.php</file>
 		</exclude>
 		<report>
 			<clover outputFile="build/phpunit/clover.xml"/>

--- a/src/Library/.github/workflows/analyze.yml
+++ b/src/Library/.github/workflows/analyze.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Run static analysis
         run: vendor/bin/phpstan analyze

--- a/src/Library/.github/workflows/compare.yml
+++ b/src/Library/.github/workflows/compare.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run comparison
         uses: docker://nyholm/roave-bc-check-ga
         env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/Library/.github/workflows/test.yml
+++ b/src/Library/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Enable Tachycardia
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV

--- a/src/Project/.github/workflows/analyze.yml
+++ b/src/Project/.github/workflows/analyze.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Run static analysis
         run: vendor/bin/phpstan analyze

--- a/src/Project/.github/workflows/test.yml
+++ b/src/Project/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Enable Tachycardia
         run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV


### PR DESCRIPTION
Removes reliance on the `COMPOSER_AUTH` secret from workflows so actions triggered from forks will still run.